### PR TITLE
Adding -include option and moving to yargs from commander package for…

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,7 +7,32 @@ var fs = require('fs');
 var path = require('path');
 var util = require('util');
 
-var program = require('commander');
+var argv = require('yargs')
+  .usage('Usage: $0 <command> [options]')
+  .command('$0', 'Browse file system.')
+  .example('$0 -e .js .swf .apk', 'Exclude extensions while browsing.')
+  .alias('i', 'include')
+  .array('i')
+  .describe('i', 'File extension to include.')
+  .alias('e', 'exclude')
+  .array('e')
+  .describe('e', 'File extensions to exclude.')
+  .alias('p', 'port')
+  .describe('p', 'Port to run the file-browser. [default:8088]')
+  .help('h')
+  .alias('h', 'help')
+  // .describe('h', '')
+  // .epilog('copyright 2015')
+  // .demandOption(['i', 'e']) // required fields
+  .check(_checkValidity)
+  .argv;
+
+function _checkValidity(argv) {
+  if (argv.i && argv.e) return new Error('Select -i or -e.');
+  if (argv.i && argv.i.length == 0) return new Error('Supply at least one extension for -i option.');
+  if (argv.e && argv.e.length == 0) return new Error('Supply at least one extension for -e option.');
+  return true;
+}
 
 function collect(val, memo) {
   if(val && val.indexOf('.') != 0) val = "." + val;
@@ -15,21 +40,16 @@ function collect(val, memo) {
   return memo;
 }
 
-program
-  .option('-p, --port <port>', 'Port to run the file-browser. Default value is 8088')
-  .option('-e, --exclude <exclude>', 'File extensions to exclude. To exclude multiple extension pass -e multiple times. e.g. ( -e .js -e .cs -e .swp) ', collect, [])
-  .parse(process.argv);
-
 var app = express();
 var dir =  process.cwd();
 app.use(express.static(dir)); //app public directory
 app.use(express.static(__dirname)); //module directory
 var server = http.createServer(app);
 
-if(!program.port) program.port = 8088;
+if(!argv.port) argv.port = 8088;
 
-server.listen(program.port);
-console.log("Please open the link in your browser http://<YOUR-IP>:" + program.port);
+server.listen(argv.port);
+console.log("Please open the link in your browser http://localhost:" + argv.port);
 
 app.get('/files', function(req, res) {
  var currentDir =  dir;
@@ -44,7 +64,8 @@ app.get('/files', function(req, res) {
       files
       .filter(function (file) {
           return true;
-      }).forEach(function (file) {
+      })
+      .forEach(function (file) {
         try {
                 //console.log("processing ", file);
                 var isDirectory = fs.statSync(path.join(currentDir,file)).isDirectory();
@@ -52,17 +73,21 @@ app.get('/files', function(req, res) {
                   data.push({ Name : file, IsDirectory: true, Path : path.join(query, file)  });
                 } else {
                   var ext = path.extname(file);
-                  if(program.exclude && _.contains(program.exclude, ext)) {
+                  if(argv.exclude && _.contains(argv.exclude, ext)) {
                     console.log("excluding file ", file);
                     return;
-                  }       
+                  }
+                  else if(argv.include && !_.contains(argv.include, ext)) {
+                    console.log("not including file", file);
+                    return;
+                  }
                   data.push({ Name : file, Ext : ext, IsDirectory: false, Path : path.join(query, file) });
                 }
 
         } catch(e) {
-          console.log(e); 
-        }        
-        
+          console.log(e);
+        }
+
       });
       data = _.sortBy(data, function(f) { return f.Name });
       res.json(data);

--- a/package.json
+++ b/package.json
@@ -19,8 +19,8 @@
   },
   "dependencies": {
     "express": "~4.4",
-    "lodash" : "~2.4",
-    "commander" : "~2.3"
+    "lodash": "~2.4",
+    "yargs": "8.0.2"
   },
   "devDependencies": {
     "mocha": "1.20.1"


### PR DESCRIPTION
I have added a include option to list only files with supplied extensions. Also changed argument parser module from commander to yargs because commander has some issues with variadic arguments. Now include and exclude options can be followed by white-space separated extensions.